### PR TITLE
Initial housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Housekeeping
 
 -   Fixed linting issues with chevron icon in header (#17)
+-   Renamed anything to do with editor pane sizing to be more appropriate for the current interface logic (#14)
 
 ## 0.1.0.80
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0.81
+
+### Housekeeping
+
+-   Fixed linting issues with chevron icon in header (#17)
+
 ## 0.1.0.80
 
 ### Improvements

--- a/src/components/editor/EditorHeadingExpanded.tsx
+++ b/src/components/editor/EditorHeadingExpanded.tsx
@@ -16,7 +16,8 @@ const EditorHeadingExpanded = () => {
             Debugger.log('Toggling pane expansion...');
             dispatch(toggleEditorPane());
         },
-        tooltip_i18_key = 'Tooltip_Collapse_Editor_Pane';
+        tooltip_i18_key = 'Tooltip_Collapse_Editor_Pane',
+        iconName = position === 'left' ? 'ChevronLeft' : 'ChevronRight';
 
     return (
         <>
@@ -43,12 +44,7 @@ const EditorHeadingExpanded = () => {
                     className='editor-collapse'
                     onClick={togglePane}
                 >
-                    <FontIcon
-                        iconName={
-                            position === 'left' ? 'ChevronLeft' : 'ChevronRight'
-                        }
-                        className={buttonIconClass}
-                    />
+                    <FontIcon iconName={iconName} className={buttonIconClass} />
                 </div>
             </TooltipHost>
         </>

--- a/src/components/editor/EditorInterface.tsx
+++ b/src/components/editor/EditorInterface.tsx
@@ -13,8 +13,8 @@ import NewVisualDialog from '../create/NewVisualDialog';
 const EditorInterface: React.FC = () => {
     Debugger.log('Rendering Component: [EditorInterface]...');
     const {
-            editorPaneDefaultWidth,
-            editorPaneWidth,
+            resizablePaneDefaultWidth,
+            resizablePaneWidth,
             editorPaneIsExpanded,
             settings
         } = useSelector(state).visual,
@@ -34,9 +34,9 @@ const EditorInterface: React.FC = () => {
             event.preventDefault();
             if (editorPaneIsExpanded) {
                 Debugger.log(
-                    `Resetting pane to default - ${editorPaneDefaultWidth}px...`
+                    `Resetting pane to default - ${resizablePaneDefaultWidth}px...`
                 );
-                handleResize(editorPaneDefaultWidth);
+                handleResize(resizablePaneDefaultWidth);
             }
         },
         editorPane = (
@@ -55,9 +55,9 @@ const EditorInterface: React.FC = () => {
         <div id='visualEditor'>
             <SplitPane
                 split='vertical'
-                minSize={renderingService.resolveEditorPaneMinSize()}
-                maxSize={renderingService.resolveEditorPaneMaxSize()}
-                size={editorPaneWidth}
+                minSize={renderingService.getResizablePaneMinSize()}
+                maxSize={renderingService.getResizablePaneMaxSize()}
+                size={resizablePaneWidth}
                 onChange={handleResize}
                 onResizerDoubleClick={resolveDoubleClick}
                 allowResize={editorPaneIsExpanded}

--- a/src/components/editor/EditorPaneCollapsed.tsx
+++ b/src/components/editor/EditorPaneCollapsed.tsx
@@ -16,7 +16,8 @@ const EditorPaneCollapsed = () => {
             Debugger.log('Toggling pane expansion...');
             dispatch(toggleEditorPane());
         },
-        tooltip_i18_key = 'Tooltip_Expand_Editor_Pane';
+        tooltip_i18_key = 'Tooltip_Expand_Editor_Pane',
+        iconName = position === 'left' ? 'ChevronRight' : 'ChevronLeft';
 
     return (
         <div id='editorPane' className='collapsed'>
@@ -27,11 +28,7 @@ const EditorPaneCollapsed = () => {
                 <div onClick={togglePane} role='button'>
                     <div role='button' className='editor-expand'>
                         <FontIcon
-                            iconName={
-                                position === 'left'
-                                    ? 'ChevronRight'
-                                    : 'ChevronLeft'
-                            }
+                            iconName={iconName}
                             className={buttonIconClass}
                         />
                     </div>

--- a/src/config/visualReducer.ts
+++ b/src/config/visualReducer.ts
@@ -21,10 +21,7 @@ const visualReducer: IVisualSliceState = {
     dataViewObjects: {},
     dataWindowsLoaded: 0,
     editMode: EditMode.Default,
-    editorPaneDefaultWidth: null,
-    editorPaneExpandedWidth: null,
     editorPaneIsExpanded: true,
-    editorPaneWidth: null,
     fixResult: {
         success: true,
         dismissed: false,
@@ -38,6 +35,9 @@ const visualReducer: IVisualSliceState = {
     launchUrl: null,
     loader: specificationService.resolveLoaderLogic(),
     locale: '',
+    resizablePaneDefaultWidth: null,
+    resizablePaneExpandedWidth: null,
+    resizablePaneWidth: null,
     selectedOperation: 'spec',
     selectionManager: null,
     spec: {

--- a/src/services/RenderingService.ts
+++ b/src/services/RenderingService.ts
@@ -39,7 +39,7 @@ export class RenderingService implements IRenderingService {
     }
 
     @standardLog()
-    getDefaultEditorPaneWidthInPx(
+    getResizablePaneDefaultWidth(
         viewport: IViewport,
         position: TEditorPosition
     ) {
@@ -50,8 +50,8 @@ export class RenderingService implements IRenderingService {
     }
 
     @standardLog()
-    resolveEditorPaneSize(
-        editorPaneExpandedWidth: number,
+    getResizablePaneSize(
+        paneExpandedWidth: number,
         editorPaneIsExpanded: boolean,
         viewport: IViewport,
         position: TEditorPosition
@@ -61,16 +61,16 @@ export class RenderingService implements IRenderingService {
                     ? viewport.width - splitPaneDefaults.collapsedSize
                     : splitPaneDefaults.collapsedSize,
             resolvedWidth =
-                (editorPaneIsExpanded && editorPaneExpandedWidth) ||
+                (editorPaneIsExpanded && paneExpandedWidth) ||
                 (editorPaneIsExpanded &&
-                    this.getDefaultEditorPaneWidthInPx(viewport, position)) ||
+                    this.getResizablePaneDefaultWidth(viewport, position)) ||
                 collapsedSize;
         Debugger.log(`Pane width resolved as ${resolvedWidth}px`);
         return resolvedWidth;
     }
 
     @standardLog()
-    resolveEditorPaneMinSize() {
+    getResizablePaneMinSize() {
         Debugger.log('Resolving minimum size for pane...');
         const {
                 editorPaneIsExpanded,
@@ -95,7 +95,7 @@ export class RenderingService implements IRenderingService {
     }
 
     @standardLog()
-    resolveEditorPaneMaxSize() {
+    getResizablePaneMaxSize() {
         Debugger.log('Resolving maximum size for pane...');
         const {
                 editorPaneIsExpanded,
@@ -117,7 +117,7 @@ export class RenderingService implements IRenderingService {
     @standardLog()
     calculateVegaViewport(
         viewport: IViewport,
-        editorPaneWidth: number,
+        paneWidth: number,
         interfaceType: TVisualInterface,
         position: TEditorPosition
     ) {
@@ -125,8 +125,8 @@ export class RenderingService implements IRenderingService {
             width =
                 (interfaceType === 'Edit' &&
                     (position === 'right'
-                        ? editorPaneWidth
-                        : viewport.width - editorPaneWidth)) ||
+                        ? paneWidth
+                        : viewport.width - paneWidth)) ||
                 viewport.width;
         height -= visualViewportAdjust.top;
         width -= visualViewportAdjust.left;

--- a/src/store/visualReducer.ts
+++ b/src/store/visualReducer.ts
@@ -61,25 +61,25 @@ const visualSlice = createSlice({
                 <IVisualSliceState>state
             );
             Debugger.log(`Interface type: ${interfaceType}`);
-            state.editorPaneDefaultWidth = renderingService.getDefaultEditorPaneWidthInPx(
+            state.resizablePaneDefaultWidth = renderingService.getResizablePaneDefaultWidth(
                 pl.options.viewport,
                 state.settings.editor.position
             );
 
             if (interfaceType === 'Edit') {
-                if (state.editorPaneWidth === null || positionSwitch) {
-                    state.editorPaneWidth = state.editorPaneDefaultWidth;
+                if (state.resizablePaneWidth === null || positionSwitch) {
+                    state.resizablePaneWidth = state.resizablePaneDefaultWidth;
                 }
-                if (state.editorPaneExpandedWidth === null || positionSwitch) {
-                    state.editorPaneExpandedWidth = renderingService.getDefaultEditorPaneWidthInPx(
+                if (state.resizablePaneExpandedWidth === null || positionSwitch) {
+                    state.resizablePaneExpandedWidth = renderingService.getResizablePaneDefaultWidth(
                         pl.options.viewport,
                         state.settings.editor.position
                     );
                 }
             }
             state.interfaceType = interfaceType;
-            state.editorPaneWidth = renderingService.resolveEditorPaneSize(
-                state.editorPaneExpandedWidth,
+            state.resizablePaneWidth = renderingService.getResizablePaneSize(
+                state.resizablePaneExpandedWidth,
                 state.editorPaneIsExpanded,
                 state.viewport,
                 state.settings.editor.position
@@ -88,7 +88,7 @@ const visualSlice = createSlice({
             // Resolve visual viewport
             state.vegaViewport = renderingService.calculateVegaViewport(
                 state.viewport,
-                state.editorPaneWidth,
+                state.resizablePaneWidth,
                 state.interfaceType,
                 state.settings.editor.position
             );
@@ -117,8 +117,8 @@ const visualSlice = createSlice({
             state.interfaceType = renderingService.resolveInterfaceType(
                 <IVisualSliceState>state
             );
-            state.editorPaneWidth = renderingService.resolveEditorPaneSize(
-                state.editorPaneExpandedWidth,
+            state.resizablePaneWidth = renderingService.getResizablePaneSize(
+                state.resizablePaneExpandedWidth,
                 state.editorPaneIsExpanded,
                 state.viewport,
                 state.settings.editor.position
@@ -156,19 +156,19 @@ const visualSlice = createSlice({
                 state.interfaceType,
                 state.settings.editor.position
             );
-            state.editorPaneWidth = editorPaneWidth;
-            state.editorPaneExpandedWidth = editorPaneExpandedWidth;
+            state.resizablePaneWidth = editorPaneWidth;
+            state.resizablePaneExpandedWidth = editorPaneExpandedWidth;
         },
         toggleEditorPane: (state) => {
             const newExpansionState = !state.editorPaneIsExpanded,
-                newWidth = renderingService.resolveEditorPaneSize(
-                    state.editorPaneExpandedWidth,
+                newWidth = renderingService.getResizablePaneSize(
+                    state.resizablePaneExpandedWidth,
                     newExpansionState,
                     state.viewport,
                     state.settings.editor.position
                 );
             state.editorPaneIsExpanded = newExpansionState;
-            state.editorPaneWidth = newWidth;
+            state.resizablePaneWidth = newWidth;
             state.vegaViewport = renderingService.calculateVegaViewport(
                 state.viewport,
                 newWidth,

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,49 +252,49 @@ export interface IRenderingService {
      */
     resolveInterfaceType: (state: IVisualSliceState) => TVisualInterface;
     /**
-     * Calculate the default size of the editor pane (in px) based on current viewport size and config defaults.
+     * Calculate the default size of the resizable pane (in px) based on current viewport size and config defaults.
      *
      * @param viewport - current visual viewport dimensions.
      * @param position - current editor position.
      */
-    getDefaultEditorPaneWidthInPx: (
+    getResizablePaneDefaultWidth: (
         viewport: IViewport,
         position: TEditorPosition
     ) => number;
     /**
-     * Based on the current state of the editor pane, resolve its actual width on the screen.
+     * Based on the current state of the resizable pane, resolve its actual width on the screen.
      *
-     * @param editorPaneExpandedWidth - current width of the expanded editor pane.
-     * @param editorPaneIsExpanded - flag confirming whether pane is expanded or collapsed.
+     * @param paneExpandedWidth - current width of the expanded resizable pane.
+     * @param editorPaneIsExpanded - flag confirming whether editor pane is expanded or collapsed.
      * @param viewport - current visual viewport dimensions.
      * @param position - current editor position.
      */
-    resolveEditorPaneSize: (
-        editorPaneExpandedWidth: number,
+    getResizablePaneSize: (
+        paneExpandedWidth: number,
         editorPaneIsExpanded: boolean,
         viewport: IViewport,
         position: TEditorPosition
     ) => number;
     /**
-     * Work out what the minimum size of the editor pane should be (in px), based on the persisted visual (store) state.
+     * Work out what the minimum size of the resizable pane should be (in px), based on the persisted visual (store) state.
      */
-    resolveEditorPaneMinSize: () => number;
+    getResizablePaneMinSize: () => number;
     /**
-     * Work out what the maximum size of the editor pane should be (in px), based on the persisted visual (store) state.
+     * Work out what the maximum size of the resizable pane should be (in px), based on the persisted visual (store) state.
      */
-    resolveEditorPaneMaxSize: () => number;
+    getResizablePaneMaxSize: () => number;
     /**
      * Calculate the dimensions of the Vega/Vega-Lite visual viewport (height/width) based on the interface state and a number
      * of other factors (including any config defaults).
      *
      * @param viewport - current visual viewport dimensions.
-     * @param editorPaneWidth - current width of editor pane.
+     * @param paneWidth - current width of resizable pane.
      * @param interfaceType - the current interface the visual is displaying for the end user.
      * @param position - current editor position.
      */
     calculateVegaViewport: (
         viewport: IViewport,
-        editorPaneWidth: number,
+        paneWidth: number,
         interfaceType: TVisualInterface,
         position: TEditorPosition
     ) => IViewport;
@@ -439,10 +439,7 @@ export interface IVisualSliceState {
     dataViewObjects: DataViewObjects;
     dataWindowsLoaded: number;
     editMode: EditMode;
-    editorPaneDefaultWidth: number;
-    editorPaneExpandedWidth: number;
     editorPaneIsExpanded: boolean;
-    editorPaneWidth: number;
     fixResult: IFixResult;
     i18n: ILocalizationManager;
     interfaceType: TVisualInterface;
@@ -451,6 +448,9 @@ export interface IVisualSliceState {
     launchUrl: (url: string) => void;
     loader: Loader;
     locale: string;
+    resizablePaneDefaultWidth: number;
+    resizablePaneExpandedWidth: number;
+    resizablePaneWidth: number;
     settings: VisualSettings;
     selectedOperation: TEditorOperation;
     selectionManager: ISelectionManager;


### PR DESCRIPTION
-   Fixed linting issues with chevron icon in header (#17)
-   Renamed anything to do with editor pane sizing to be more appropriate for the current interface logic (#14)