### PR TITLE
Dev mode locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 ## 0.2.0.81
 
-### Improvements
-
--   Added switchable locale in dev tools, which will assist with debugging formatting and other i18n stuff (#19)
-
-### Housekeeping
-
--   Fixed linting issues with chevron icon in header (#17)
--   Renamed anything to do with editor pane sizing to be more appropriate for the current interface logic (#14)
+As of this build, please refer to the [documentation website](http://deneb-viz.github.io/) or individual GitHub releases for change details.
 
 ## 0.1.0.80
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.0.81
 
+### Improvements
+
+-   Added switchable locale in dev tools, which will assist with debugging formatting and other i18n stuff (#19)
+
 ### Housekeeping
 
 -   Fixed linting issues with chevron icon in header (#17)

--- a/capabilities.json
+++ b/capabilities.json
@@ -34,7 +34,7 @@
                                 "value": "de-DE"
                             },
                             {
-                                "displayNameKey": "Enum_Locale_fr-DE",
+                                "displayNameKey": "Enum_Locale_fr-FR",
                                 "displayName": "fr-FR",
                                 "value": "fr-FR"
                             }

--- a/capabilities.json
+++ b/capabilities.json
@@ -10,6 +10,39 @@
         }
     ],
     "objects": {
+        "developer": {
+            "displayNameKey": "Objects_Developer",
+            "descriptionKey": "Objects_Developer_Description",
+            "displayName": "Developer Options",
+            "description": "Developer Options description.",
+            "properties": {
+                "locale": {
+                    "displayNameKey": "Objects_Developer_Locale",
+                    "descriptionKey": "Objects_Developer_Locale_Description",
+                    "displayName": "Locale",
+                    "description": "Locale description.",
+                    "type": {
+                        "enumeration": [
+                            {
+                                "displayNameKey": "Enum_Locale_en-US",
+                                "displayName": "en-US",
+                                "value": "en-US"
+                            },
+                            {
+                                "displayNameKey": "Enum_Locale_de-DE",
+                                "displayName": "de-DE",
+                                "value": "de-DE"
+                            },
+                            {
+                                "displayNameKey": "Enum_Locale_fr-DE",
+                                "displayName": "fr-FR",
+                                "value": "fr-FR"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
         "vega": {
             "displayNameKey": "Objects_Vega",
             "descriptionKey": "Objects_Vega_Description",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "office-ui-fabric-react": "^7.156.0",
         "powerbi-visuals-api": "3.4.0",
         "powerbi-visuals-utils-dataviewutils": "2.2.1",
+        "powerbi-visuals-utils-formattingutils": "^4.7.1",
         "powerbi-visuals-utils-interactivityutils": "^5.7.0",
         "prettier": "^2.2.1",
         "react": "^17.0.1",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,7 +4,7 @@
         "displayName": "Deneb",
         "guid": "deneb7E15AEF80B9E4D4F8E12924291ECE89A",
         "visualClassName": "Deneb",
-        "version": "0.1.0.80-beta",
+        "version": "0.2.0.81-beta",
         "description": "Declarative visualization in Power BI, using the Vega language.",
         "supportUrl": "https://deneb-viz.github.io/",
         "gitHubUrl": "https://github.com/deneb-viz/deneb"

--- a/src/components/VisualRender.tsx
+++ b/src/components/VisualRender.tsx
@@ -39,6 +39,7 @@ const VisualRender = () => {
             locales.format[locale] || locales.format[locales.default],
         timeFormatLocale =
             locales.timeFormat[locale] || locales.timeFormat[locales.default];
+    specificationService.registerCustomExpressions();
 
     switch (spec?.status) {
         case 'error': {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,7 +3,7 @@ import Ace = ace.Ace;
 
 import { visual } from '../../pbiviz.json';
 import { devDependencies } from '../../package.json';
-import { TEditorPosition, TSpecProvider, TSpecRenderMode } from '../types';
+import { TEditorPosition, TLocale, TSpecProvider, TSpecRenderMode } from '../types';
 import { locales } from './locales';
 import { theme } from './theme';
 import { CommandService } from '../services/CommandService';
@@ -13,6 +13,7 @@ import { CommandService } from '../services/CommandService';
  */
 export {
     dataLimitDefaults,
+    developerDefaults,
     editorDefaults,
     editorKeyBindings,
     locales,
@@ -101,6 +102,18 @@ const splitPaneDefaults = {
     maxSizePercent: 0.6,
     // The width of the collapsed editor pane (px).
     collapsedSize: 36
+};
+
+/**
+ * =======================
+ * Developer Mode Defaults
+ * =======================
+ * 
+ * When developer mode is enabled, we have a specific object and properties available, so we'll add any
+ * suitable defaults to this object.
+ */
+const developerDefaults = {
+    locale: <TLocale>'en-US'
 };
 
 /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,7 +3,12 @@ import Ace = ace.Ace;
 
 import { visual } from '../../pbiviz.json';
 import { devDependencies } from '../../package.json';
-import { TEditorPosition, TLocale, TSpecProvider, TSpecRenderMode } from '../types';
+import {
+    TEditorPosition,
+    TLocale,
+    TSpecProvider,
+    TSpecRenderMode
+} from '../types';
 import { locales } from './locales';
 import { theme } from './theme';
 import { CommandService } from '../services/CommandService';
@@ -108,7 +113,7 @@ const splitPaneDefaults = {
  * =======================
  * Developer Mode Defaults
  * =======================
- * 
+ *
  * When developer mode is enabled, we have a specific object and properties available, so we'll add any
  * suitable defaults to this object.
  */

--- a/src/properties/DeveloperSettings.ts
+++ b/src/properties/DeveloperSettings.ts
@@ -1,0 +1,37 @@
+import powerbi from 'powerbi-visuals-api';
+import VisualObjectInstanceEnumerationObject = powerbi.VisualObjectInstanceEnumerationObject;
+
+import SettingsBase from './SettingsBase';
+import Debugger from '../Debugger';
+import { visualFeatures } from '../config';
+import { TLocale } from '../types';
+
+/**
+ * Manages data limit override preferences for the visual.
+ */
+export default class DeveloperSettings extends SettingsBase {
+    // Locale override for testing formatting and i18n
+    public locale: TLocale = 'en-US';
+
+    /**
+     * Business logic for the properties within this menu.
+     * @param enumerationObject - `VisualObjectInstanceEnumerationObject` to process.
+     * @param options           - any specific options we wish to pass from elsewhere in the visual that our settings may depend upon.
+     */
+    public processEnumerationObject(
+        enumerationObject: VisualObjectInstanceEnumerationObject,
+        options: {
+            [propertyName: string]: any;
+        } = {}
+    ): VisualObjectInstanceEnumerationObject {
+        Debugger.log('Processing enumeration...');
+        enumerationObject.instances.map((i) => {
+            if (!visualFeatures.developerMode) {
+                Debugger.log("Removing object & properties...");
+                enumerationObject.instances = [];
+            }
+        });
+        return enumerationObject;
+    }
+
+}

--- a/src/properties/DeveloperSettings.ts
+++ b/src/properties/DeveloperSettings.ts
@@ -27,11 +27,10 @@ export default class DeveloperSettings extends SettingsBase {
         Debugger.log('Processing enumeration...');
         enumerationObject.instances.map((i) => {
             if (!visualFeatures.developerMode) {
-                Debugger.log("Removing object & properties...");
+                Debugger.log('Removing object & properties...');
                 enumerationObject.instances = [];
             }
         });
         return enumerationObject;
     }
-
 }

--- a/src/properties/EditorSettings.ts
+++ b/src/properties/EditorSettings.ts
@@ -1,14 +1,11 @@
-import powerbi from 'powerbi-visuals-api';
-import VisualObjectInstanceEnumerationObject = powerbi.VisualObjectInstanceEnumerationObject;
-
 import SettingsBase from './SettingsBase';
 import { editorDefaults as defaults } from '../config';
 import { TEditorPosition } from '../types';
 
 /**
- * Manages data limit override preferences for the visual.
+ * Manages editor preferences for the visual.
  */
 export default class EditorSettings extends SettingsBase {
-    // Feature enabled or not
+    // Preferred editor position within interface
     public position: TEditorPosition = defaults.position;
 }

--- a/src/properties/VisualSettings.ts
+++ b/src/properties/VisualSettings.ts
@@ -1,11 +1,13 @@
 import { dataViewObjectsParser } from 'powerbi-visuals-utils-dataviewutils';
 import DataViewObjectsParser = dataViewObjectsParser.DataViewObjectsParser;
 
+import DeveloperSettings from './DeveloperSettings';
 import VegaSettings from './VegaSettings';
 import DataLimitSettings from './DataLimitSettings';
 import EditorSettings from './EditorSettings';
 
 export default class VisualSettings extends DataViewObjectsParser {
+    public developer = new DeveloperSettings();
     public vega = new VegaSettings();
     public editor = new EditorSettings();
     public dataLimit = new DataLimitSettings();

--- a/src/services/SpecificationService.ts
+++ b/src/services/SpecificationService.ts
@@ -1,10 +1,12 @@
 import powerbi from 'powerbi-visuals-api';
 import ISelectionId = powerbi.visuals.ISelectionId;
+import { valueFormatter } from 'powerbi-visuals-utils-formattingutils';
 
 import jsonrepair from 'jsonrepair';
 import * as Vega from 'vega';
 import Config = Vega.Config;
 import Spec = Vega.Spec;
+import expressionFunction = Vega.expressionFunction;
 import * as VegaLite from 'vega-lite';
 import { TopLevelSpec } from 'vega-lite';
 
@@ -256,12 +258,31 @@ export class SpecificationService implements ISpecificationHandlerService {
         return {
             ...{
                 background: null, // so we can defer to the Power BI background, if applied
+                customFormatTypes: true,
                 range: {
                     category: themeColors
                 }
             },
             ...this.getParsedConfigFromSettings()
         };
+    }
+
+    @standardLog()
+    registerCustomExpressions() {
+        const { locale } = store.getState().visual;
+        Debugger.log('Registering custom formatters...');
+        expressionFunction('pbiFormat', (datum: any, params: string) => {
+            Debugger.log(
+                `Formatting value: ${datum} with format "${params}"...`
+            );
+            const fmt = valueFormatter.create({
+                    format: `${params}`,
+                    cultureSelector: locale
+                }),
+                value = fmt.format(datum);
+            Debugger.log(`Formatted value: ${value}`);
+            return value;
+        });
     }
 
     /**

--- a/src/store/visualReducer.ts
+++ b/src/store/visualReducer.ts
@@ -74,7 +74,10 @@ const visualSlice = createSlice({
                 if (state.resizablePaneWidth === null || positionSwitch) {
                     state.resizablePaneWidth = state.resizablePaneDefaultWidth;
                 }
-                if (state.resizablePaneExpandedWidth === null || positionSwitch) {
+                if (
+                    state.resizablePaneExpandedWidth === null ||
+                    positionSwitch
+                ) {
                     state.resizablePaneExpandedWidth = renderingService.getResizablePaneDefaultWidth(
                         pl.options.viewport,
                         state.settings.editor.position

--- a/src/store/visualReducer.ts
+++ b/src/store/visualReducer.ts
@@ -18,6 +18,7 @@ import {
 } from '../types';
 import Debugger from '../Debugger';
 import { visualReducer as initialState } from '../config/visualReducer';
+import { visualFeatures } from '../config';
 
 const visualSlice = createSlice({
     name: 'visual',
@@ -56,6 +57,9 @@ const visualSlice = createSlice({
             state.dataViewObjects =
                 pl.options.dataViews[0]?.metadata.objects || {};
 
+            if (visualFeatures.developerMode) {
+                state.locale = pl.settings?.developer?.locale || state.locale;
+            }
             // If editing report and focus mode, then we're in the editor
             const interfaceType = renderingService.resolveInterfaceType(
                 <IVisualSliceState>state

--- a/src/templates/vega/vBarSimple.ts
+++ b/src/templates/vega/vBarSimple.ts
@@ -12,7 +12,7 @@ export const vBarSimple: IVegaTemplate = {
                 name: 'yscale',
                 type: 'band',
                 domain: {
-                    data: 'values',
+                    data: 'dataset',
                     field: '$yAxis$'
                 },
                 range: 'height',
@@ -22,7 +22,7 @@ export const vBarSimple: IVegaTemplate = {
             {
                 name: 'xscale',
                 domain: {
-                    data: 'values',
+                    data: 'dataset',
                     field: '$xAxis$'
                 },
                 nice: true,
@@ -45,7 +45,7 @@ export const vBarSimple: IVegaTemplate = {
             {
                 type: 'rect',
                 from: {
-                    data: 'values'
+                    data: 'dataset'
                 },
                 encode: {
                     enter: {

--- a/src/templates/vega/vLineConfInterval.ts
+++ b/src/templates/vega/vLineConfInterval.ts
@@ -11,7 +11,7 @@ export const vLineConfInterval: IVegaTemplate = {
             {
                 name: 'xscale',
                 domain: {
-                    data: 'values',
+                    data: 'dataset',
                     field: '$xAxis$'
                 },
                 range: 'width',
@@ -20,7 +20,7 @@ export const vLineConfInterval: IVegaTemplate = {
             {
                 name: 'yscale',
                 domain: {
-                    data: 'values',
+                    data: 'dataset',
                     field: '$maxValue$'
                 },
                 range: 'height',
@@ -48,7 +48,7 @@ export const vLineConfInterval: IVegaTemplate = {
                     field: 'datum["$xAxis$"]'
                 },
                 from: {
-                    data: 'values'
+                    data: 'dataset'
                 },
                 encode: {
                     update: {
@@ -84,7 +84,7 @@ export const vLineConfInterval: IVegaTemplate = {
                     field: 'datum["$xAxis$"]'
                 },
                 from: {
-                    data: 'values'
+                    data: 'dataset'
                 },
                 encode: {
                     update: {

--- a/src/templates/vega/vScatterColored.ts
+++ b/src/templates/vega/vScatterColored.ts
@@ -8,7 +8,7 @@ export const vScatterColored: IVegaTemplate = {
     spec: {
         data: [
             {
-                name: 'values',
+                name: 'dataset',
                 transform: [
                     {
                         type: 'filter',
@@ -22,7 +22,7 @@ export const vScatterColored: IVegaTemplate = {
             {
                 name: 'xscale',
                 domain: {
-                    data: 'values',
+                    data: 'dataset',
                     field: '$xAxis$'
                 },
                 range: 'width',
@@ -31,7 +31,7 @@ export const vScatterColored: IVegaTemplate = {
             {
                 name: 'yscale',
                 domain: {
-                    data: 'values',
+                    data: 'dataset',
                     field: '$yAxis$'
                 },
                 range: 'height',
@@ -41,7 +41,7 @@ export const vScatterColored: IVegaTemplate = {
                 name: 'color',
                 type: 'ordinal',
                 domain: {
-                    data: 'values',
+                    data: 'dataset',
                     field: '$series$',
                     sort: true
                 },
@@ -66,7 +66,7 @@ export const vScatterColored: IVegaTemplate = {
                 type: 'symbol',
                 style: ['point'],
                 from: {
-                    data: 'values'
+                    data: 'dataset'
                 },
                 encode: {
                     update: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,8 @@ export type TSupportedValueTypeDescriptor =
     | 'dateTime'
     | 'duration'
     | 'binary';
+// Locales (currently for debugging only)
+export type TLocale = 'en-US' | 'de-DE' | 'fr-FR';
 
 /**
  * ========

--- a/src/types.ts
+++ b/src/types.ts
@@ -384,6 +384,10 @@ export interface ISpecificationHandlerService {
      * to make things as "at home" in Power BI as possible.
      */
     getInitialConfig: () => void;
+    /**
+     * Apply any custom expressions that we have written (e.g. formatting) to the specification prior to rendering.
+     */
+    registerCustomExpressions: () => void;
 }
 
 /**

--- a/stringResources/en-US/resources.resjson
+++ b/stringResources/en-US/resources.resjson
@@ -1,6 +1,13 @@
 {
     "Roles_Values": "Values",
     "Roles_Values_Description": "Visual data values.",
+    "Objects_Developer": "Developer Menu",
+    "Objects_Developer_Description": "Options used for development of the visual.",
+    "Objects_Developer_Locale": "Locale",
+    "Objects_Developer_Locale_Description": "Provide a manual locale for the visual (to facilitate testing of i18n and formatting)",
+    "Enum_Locale_en-US": "English",
+    "Enum_Locale_de-DE": "Deutsch",
+    "Enum_Locale_fr-FR": "français",
     "Objects_Vega": "Vega",
     "Objects_Vega_Description": "Properties that manage the supplied source code for the visual.",
     "Objects_Vega_JsonSpec": "JSON Spec",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,6 +1708,19 @@ powerbi-visuals-utils-dataviewutils@2.2.1:
   resolved "https://registry.yarnpkg.com/powerbi-visuals-utils-dataviewutils/-/powerbi-visuals-utils-dataviewutils-2.2.1.tgz#52656d657b8b1adfb78da1fb62f4fa311c580303"
   integrity sha512-Ai+TM1gj6DpAsNbn0IhOwUCAPfcaH4Z7y6Ow2OwAfbxNpELwQSF0S8D+vlJN2AoqV/ruQhnEngUC88mMFNyvJQ==
 
+powerbi-visuals-utils-dataviewutils@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/powerbi-visuals-utils-dataviewutils/-/powerbi-visuals-utils-dataviewutils-2.4.1.tgz#8657a24d773ac9e471b621195f04e9a24ccd8138"
+  integrity sha512-xgI4ru1KWcYFTbftLsR7Pzg14cslVPajUZUyRk6nzCEQvUMN/kVtPpVT5+s8UuhDZe7zpqSDAhSGS5yAcn9GcA==
+
+powerbi-visuals-utils-formattingutils@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/powerbi-visuals-utils-formattingutils/-/powerbi-visuals-utils-formattingutils-4.7.1.tgz#6e8233cbf90d4770595f889eea6f5afacc055475"
+  integrity sha512-17pOtW+UNjhPz+dotk9Cu9FBLPueVU0MV6uXPjlu6Uu7YvqA/7GCUsopAq/erCI8e8vgTQZkHy9jwGbPJM+LaQ==
+  dependencies:
+    powerbi-visuals-utils-dataviewutils "2.4.1"
+    powerbi-visuals-utils-typeutils "2.3.1"
+
 powerbi-visuals-utils-interactivityutils@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/powerbi-visuals-utils-interactivityutils/-/powerbi-visuals-utils-interactivityutils-5.7.0.tgz#bf4bf45636612ae3305ddf340a959d419da30e00"
@@ -1730,6 +1743,13 @@ powerbi-visuals-utils-typeutils@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/powerbi-visuals-utils-typeutils/-/powerbi-visuals-utils-typeutils-2.3.0.tgz#59594be462cabd072f2df409fad01368081ce017"
   integrity sha512-Bv3aHTS1jkLh4v7FY1eMf2r0PzHkO4OR/b677nRlanKiuCglSFAmUC7PTKbp2+sFpHyDi6V/8nE1QCVWnczfRw==
+  dependencies:
+    coveralls "^3.1.0"
+
+powerbi-visuals-utils-typeutils@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/powerbi-visuals-utils-typeutils/-/powerbi-visuals-utils-typeutils-2.3.1.tgz#b5bcc4764513a9afcd8a1a090f7fd11ae26c6855"
+  integrity sha512-mO2MCTR/nqbQjtZDZTP7k80Sr/oNNIR6a2t5s6fmn9yGoRS4ne7ZNJRhNnyBbyz9Frapvqnr1/OeBuRUYnU1jw==
   dependencies:
     coveralls "^3.1.0"
 


### PR DESCRIPTION
# Improvements

-   Custom formatter added, which if specified, allows creators to use Power BI format strings instead of D3 ones. Refer to [Formatting Values](/formatting-values) page for details (#13)
- Added switchable locale in dev tools, which will assist with debugging formatting and other i18n stuff (#19)
    - If developer mode feature switch is on, then we can manually override  via menu rather than having to change Power BI settings
    - Otherwise reverts to visual locale as normal.
    - Currently just have en-US, de-DE and fr-FR, which should be enough for now.

# Housekeeping

-   Fixed linting issues with chevron icon in header (#17)
-   Renamed anything to do with editor pane sizing to be more appropriate for the current interface logic (#14)